### PR TITLE
Support nested macros

### DIFF
--- a/pkg/macroproc/converter.go
+++ b/pkg/macroproc/converter.go
@@ -267,15 +267,7 @@ func (c *Converter) get(path ...interface{}) *BranchLocator {
 	return &branch
 }
 
-// Refresh get latest value from t and recurses into parents.
-// It is not recommended to use it, as it introduces underide
-// conflicts, e.g. any macros in an object lookup can get
-// evaluated in unpredicatable order, so some macros seen at
-// the registration stage are no longer seen when we attempt
-// to evaluate those. If we were to optimize the number of
-// times each effectively identical macro gets evaluated,
-// we could use this again, so for now we can keep this
-// method here and the notes in `*Converter.callModifiersOnce`.
+// Refresh get latest value from t and recurses into parents
 func (b *BranchLocator) Refresh(c *Converter) error {
 	v, err := c.tree.Get(b.path[1:]...)
 	if err != nil {

--- a/pkg/macroproc/converter.go
+++ b/pkg/macroproc/converter.go
@@ -266,6 +266,21 @@ func (c *Converter) get(path ...interface{}) *BranchLocator {
 	return &branch
 }
 
+// Refresh get latest value from t and recurses into parents,
+// without this nested macros don't work properly. It maybe
+// a bug to do with how NewTree(&value) is used in doIterate).
+func (b *BranchLocator) Refresh(t *Tree) error {
+	var err error
+	b.value, err = t.Get(b.path[1:]...)
+	if err != nil {
+		return fmt.Errorf("cannot to refresh value at %v – %v", b.path, err)
+	}
+	if b.parent != nil {
+		return b.parent.Refresh(t)
+	}
+	return nil
+}
+
 func (b *BranchLocator) Kind() ValueType { return b.kind }
 
 func (b *BranchLocator) Value() *Tree { return b.value }

--- a/pkg/macroproc/macros.go
+++ b/pkg/macroproc/macros.go
@@ -10,11 +10,20 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// Phases are only used a logical grouping,
+// mostly there is no need as modifiers are
+// sorted by depth, and we can apply other
+// sub-sorting methods if needed, but for
+// the time being phases are convinient to
+// keep. If it becomes tedious to maintain,
+// they can be removed.
+
 const (
 	MacrosEvalPhaseA = iota
 	MacrosEvalPhaseB
 	MacrosEvalPhaseC
 	MacrosEvalPhaseD
+	MacrosEvalPhaseE
 	MacrosEvalPhases
 )
 
@@ -23,14 +32,19 @@ var macrosEvalPhases = [MacrosEvalPhases]MacrosEvalPhase{
 	MacrosEvalPhaseB,
 	MacrosEvalPhaseC,
 	MacrosEvalPhaseD,
+	MacrosEvalPhaseE,
 }
 
 var (
+	// Phase A – branching
+
 	MacroBooleanIf = &Macro{
 		ReturnType: Null,
 		EvalPhase:  MacrosEvalPhaseA,
 		VerbName:   "If",
 	}
+
+	// Phase B – lookups
 
 	MacroBooleanLookup = &Macro{
 		ReturnType: Boolean,
@@ -58,12 +72,26 @@ var (
 		VerbName:   "Lookup",
 	}
 
-	MacroStringJoin = &Macro{
-		ReturnType: String,
+	// Phase C – importers
+
+	LoadObjectJSON = &Macro{
+		ReturnType: Object,
 		EvalPhase:  MacrosEvalPhaseC,
-		VerbName:   "Join",
+		VerbName:   "LoadJSON",
+	}
+	LoadArrayJSON = &Macro{
+		ReturnType: Array,
+		EvalPhase:  MacrosEvalPhaseC,
+		VerbName:   "LoadJSON",
 	}
 
+	// Phase D – string functions
+
+	MacroStringJoin = &Macro{
+		ReturnType: String,
+		EvalPhase:  MacrosEvalPhaseD,
+		VerbName:   "Join",
+	}
 	MacroStringAsJSON = &Macro{
 		ReturnType: String,
 		EvalPhase:  MacrosEvalPhaseD,
@@ -74,24 +102,13 @@ var (
 		EvalPhase:  MacrosEvalPhaseD,
 		VerbName:   "AsYAML",
 	}
-
 	MacroStringAsBASE64 = &Macro{
 		ReturnType: String,
 		EvalPhase:  MacrosEvalPhaseD,
 		VerbName:   "AsBASE64",
 	}
 
-	LoadObjectJSON = &Macro{
-		ReturnType: Object,
-		EvalPhase:  MacrosEvalPhaseA,
-		VerbName:   "LoadJSON",
-	}
-
-	LoadArrayJSON = &Macro{
-		ReturnType: Array,
-		EvalPhase:  MacrosEvalPhaseA,
-		VerbName:   "LoadJSON",
-	}
+	// Phase E – extra unused phase
 )
 
 func (m *Macro) String() string {

--- a/pkg/macroproc/macros_test.go
+++ b/pkg/macroproc/macros_test.go
@@ -718,7 +718,7 @@ func TestMacroObjectToJSON(t *testing.T) {
 
 	if err := conv.Run(); err != nil {
 		t.Logf("tree=%s", conv.tree)
-		t.Fatalf("failed to convert �� %v", err)
+		t.Fatalf("failed to convert – %v", err)
 	}
 
 	assert.Equal(0, len(conv.modifiers))
@@ -752,6 +752,70 @@ func TestMacroToString(t *testing.T) {
 	}
 
 	assert.Equal("kubegen.String.FooBar", m.String())
+}
+
+func TestMacroStringToBASE64(t *testing.T) {
+	conv := New()
+
+	assert := assert.New(t)
+
+	tobj1 := []byte(`{
+			"Kind": "Some",
+			"foobarString": {
+				"kubegen.String.AsBASE64":"foo:bar"
+			},
+			"foobarQuoted1": {
+				"kubegen.String.AsBASE64": {
+					"kubegen.String.AsJSON": { "foo": "bar" }
+				}
+			},
+			"foobarQuoted2": {
+				"kubegen.String.AsBASE64": "{\"foo\":\"bar\"}"
+			},
+			"foobarDoubleQuoted1": {
+				"kubegen.String.AsBASE64": {
+					"kubegen.String.AsJSON": {
+						"kubegen.String.AsJSON": { "foo": "bar" }
+					}
+				}
+			}
+	}`)
+
+	if err := conv.LoadObject(tobj1, "tobj1.json", ""); err != nil {
+		t.Fatalf("failed to load – %v", err)
+	}
+
+	conv.DefineMacro(MacroStringAsJSON, MakeModifierStringAsJSON)
+	conv.DefineMacro(MacroStringAsBASE64, MakeModifierStringAsBASE64)
+
+	if err := conv.Run(); err != nil {
+		t.Logf("tree=%s", conv.tree)
+		t.Fatalf("failed to convert – %v", err)
+	}
+
+	{
+		v, err := conv.tree.GetString("foobarString")
+		assert.Nil(err)
+		assert.Equal("ImZvbzpiYXIi", v) // "foo:bar"
+	}
+
+	{
+		v, err := conv.tree.GetString("foobarQuoted1")
+		assert.Nil(err)
+		assert.Equal("IntcImZvb1wiOlwiYmFyXCJ9Ig==", v) // "{\"foo\":\"bar\"}"
+	}
+
+	{
+		v, err := conv.tree.GetString("foobarQuoted2")
+		assert.Nil(err)
+		assert.Equal("IntcImZvb1wiOlwiYmFyXCJ9Ig==", v) // "{\"foo\":\"bar\"}"
+	}
+
+	{
+		v, err := conv.tree.GetString("foobarDoubleQuoted1")
+		assert.Nil(err)
+		assert.Equal("Ilwie1xcXCJmb29cXFwiOlxcXCJiYXJcXFwifVwiIg==", v) // "\"{\\\"foo\\\":\\\"bar\\\"}\""%
+	}
 }
 
 func _TestMacroLoadJSON(t *testing.T) {
@@ -944,4 +1008,3 @@ func TestMacroSelect(t *testing.T) {
 // - kubegen.Object.LoadYAML
 // Also:
 // - kubegen.Array.ReadBytes
-// - kubegen.String.AsBASE64

--- a/pkg/macroproc/macros_test.go
+++ b/pkg/macroproc/macros_test.go
@@ -13,7 +13,7 @@ func TestMacroModifiersDeletion(t *testing.T) {
 
 	tobj := []byte(`{
 		"Kind": "some",
-		"kubegen.Null.Delete": { "aFoodOrder": "YES" },
+		"kubegen.Object.Delete": { "aFoodOrder": "YES" },
 		"order": {
 			"potatoe": {
 				"mash": { "count": 1 },
@@ -25,11 +25,11 @@ func TestMacroModifiersDeletion(t *testing.T) {
 					"other": [
 						{
 							"kind": "sweetAndSour",
-							"kubegen.Null.Delete": "someOfThatMayBe"
+							"kubegen.Object.Delete": "someOfThatMayBe"
 						},
 						{
 							"kind": "sourCream",
-							"kubegen.Null.Delete": "yesExtraOfThatPleaseThankYou"
+							"kubegen.Object.Delete": "yesExtraOfThatPleaseThankYou"
 						}
 					]
 				}
@@ -68,7 +68,7 @@ func TestMacroModifiersDeletion(t *testing.T) {
 		"object without modifier macros should be larger")
 
 	conv.DefineMacro(&Macro{
-		ReturnType: Null,
+		ReturnType: Object,
 		EvalPhase:  MacrosEvalPhaseA,
 		VerbName:   "Delete",
 	}, func(c *Converter, branch *BranchLocator, _ *Macro) (ModifierCallback, error) {

--- a/pkg/macroproc/tree.go
+++ b/pkg/macroproc/tree.go
@@ -62,11 +62,16 @@ func (t *Tree) Len() int {
 	return len(t.self.(map[string]interface{}))
 }
 
+// BytesAsJSON returns JSON-encoded representation
+func (t *Tree) BytesAsJSON() ([]byte, error) {
+	return json.Marshal(t.self)
+}
+
 // Bytes returns JSON-encoded representation
 // it is mostly used for testing, so it will
 // panic if the object cannot be encoded
 func (t *Tree) Bytes() []byte {
-	js, err := json.Marshal(t.self)
+	js, err := t.BytesAsJSON()
 	if err != nil {
 		panic(err) // this mostly for testing, so we are okay
 	}
@@ -77,6 +82,15 @@ func (t *Tree) Bytes() []byte {
 // it is mostly used for testing, so it will
 // panic if the object cannot be encoded
 func (t *Tree) String() string { return string(t.Bytes()) }
+
+// StringAsJSON returns JSON-encoded representation
+func (t *Tree) StringAsJSON() (string, error) {
+	js, err := t.BytesAsJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(js), nil
+}
 
 func (t *Tree) makeNext(k, v interface{}) (*ValueType, error) {
 	var vt ValueType

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -53,6 +53,7 @@ func loadObjWithModuleContext(obj interface{}, data []byte, sourcePath string, i
 	mp.DefineMacro(macroproc.MacroStringJoin, macroproc.MakeModifierStringJoin)
 	mp.DefineMacro(macroproc.MacroStringAsJSON, macroproc.MakeModifierStringAsJSON)
 	mp.DefineMacro(macroproc.MacroStringAsYAML, macroproc.MakeModifierStringAsYAML)
+	mp.DefineMacro(macroproc.MacroStringAsBASE64, macroproc.MakeModifierStringAsBASE64)
 
 	if err := mp.LoadObject(data, sourcePath, instanceName); err != nil {
 		return err

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -16,7 +16,6 @@ import (
 
 func (i *Module) makeLookupModifier(c *macroproc.Converter, branch *macroproc.BranchLocator, _ *macroproc.Macro) (macroproc.ModifierCallback, error) {
 	cb := func(m *macroproc.Modifier, c *macroproc.Converter) error {
-
 		k := m.Branch.StringValue()
 		if k == nil {
 			return fmt.Errorf("attribute reference is not a string – %#v", m.Branch)

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -24,9 +24,8 @@ func (i *Module) makeLookupModifier(c *macroproc.Converter, branch *macroproc.Br
 		if !ok {
 			return fmt.Errorf("undeclared attribute %q", *k)
 		}
-		if err := v.typeCheck(m.Macro); err != nil {
-			return err
-		}
+		// A type check of value is not useful here, as we may lookup an object that
+		// may return new macros that result in a desired type in the end
 		if m.Macro.ReturnType == macroproc.Array || m.Macro.ReturnType == macroproc.Object {
 			if err := c.Overlay(m.Branch, v.Value); err != nil {
 				return err
@@ -412,36 +411,6 @@ func (i *AnyResource) load(m *Module, instance ModuleInstance) error {
 	}
 
 	m.resources[i.includedBy] = append(m.resources[i.includedBy], resources.Anything{Object: obj})
-	return nil
-}
-
-// TODO maybe this should be a more generic thing in pkg/macroproc, e.g. macro.TypeCheck(interface{})
-func (i *attribute) typeCheck(macro *macroproc.Macro) error {
-	rt := strings.Title(macro.ReturnType.String())
-	cannotConvertError := fmt.Errorf("cannot convert type %s to %s for %q", i.Type, rt, macro)
-	if i.Type != rt {
-		return cannotConvertError
-	}
-
-	switch macro.ReturnType {
-	case macroproc.Number:
-		switch i.Value.(type) {
-		case int:
-			break
-		case float64:
-			break
-		default:
-			return cannotConvertError
-		}
-	case macroproc.String:
-		switch i.Value.(type) {
-		case string:
-			break
-		default:
-			return cannotConvertError
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
- new safe methods – `*Tree.BytesAsJSON` and `*Tree.StringAsJSON`
- sort macro execution order by depth, deprecate dependency on evaluation phases (fixes #36)
- avoid early evaluation of internal and external attributes
- improve type checks
- add `kubegen.String.AsBASE64` as a test-case